### PR TITLE
Add video reveal behind first advent door

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
                         <button type="button" class="door__content__close" aria-label="Fermer la porte 1">
                             <span aria-hidden="true">&times;</span>
                         </button>
-                        <video class="door__video" controls preload="none" poster="media/cadre.jpg">
+                        <video class="door__video" controls preload="none">
                             <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4" type="video/mp4">
                             Votre navigateur ne supporte pas la lecture vidéo.
                         </video>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <div class="advent">
         <div class="advent__row">
             <div class="advent__row__cell">
-                <div class="door">
+                <div class="door door--has-video">
                     <div class="door__hinge">
                         <div class="door__hinge__pane">
                             <div class="door__hinge__pane--front door__hinge__pane--one"><span
@@ -31,6 +31,15 @@
                                 <div class="pane pane--bottom"></div>
                             </div>
                         </div>
+                    </div>
+                    <div class="door__content door__content--video" aria-hidden="true">
+                        <button type="button" class="door__content__close" aria-label="Fermer la porte 1">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                        <video class="door__video" controls preload="none" poster="media/cadre.jpg">
+                            <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4" type="video/mp4">
+                            Votre navigateur ne supporte pas la lecture vidéo.
+                        </video>
                     </div>
                 </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -169,10 +169,85 @@ font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-seri
   .door__hinge__pane--thirty-nine { --col: 3; --row: 7; }
   .door__hinge__pane--fourty { --col: 4; --row: 7; }
 
-  .cube {
+.cube {
   position: absolute;
   top: var(--cell-padding);
   left: var(--cell-padding); }
+
+.door__content {
+  position: absolute;
+  top: var(--cell-padding);
+  left: var(--cell-padding);
+  width: calc(0.8 * var(--door-size));
+  height: calc(0.8 * var(--door-size));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px;
+  box-sizing: border-box;
+  border-radius: 16px;
+  background-image: url('media/cadre.jpg');
+  background-size: cover;
+  background-position: center;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+  z-index: 0;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+}
+
+.door--opened .door__content {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.door__video {
+  width: 100%;
+  height: 100%;
+  border: none;
+  border-radius: 12px;
+  background-color: #000;
+  object-fit: cover;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.4);
+}
+
+.door__content__close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 50%;
+  background-color: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.door__content__close:hover,
+.door__content__close:focus {
+  background-color: rgba(0, 0, 0, 0.75);
+  transform: scale(1.05);
+  outline: none;
+}
+
+.door__content__close span {
+  display: block;
+  transform: translateY(-1px);
+}
+
+.door--has-video .door__hinge__pane--open {
+  pointer-events: none;
+}
 
 .cube__container {
   width: calc(0.8 * var(--door-size));

--- a/styles.css
+++ b/styles.css
@@ -186,7 +186,6 @@ font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-seri
   padding: 14px;
   box-sizing: border-box;
   border-radius: 16px;
-  background-image: url('media/cadre.jpg');
   background-size: cover;
   background-position: center;
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);


### PR DESCRIPTION
## Summary
- add a dedicated content area to door 1 that displays a framed video
- style the new surprise content, close control, and allow video controls to receive pointer events
- enhance the door script to manage accessibility, playback, and closing behaviour for the video door

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8a2b9b91c832590053bbc11414336