### PR TITLE
Fix door overlap and modal content stacking

### DIFF
--- a/door-content.json
+++ b/door-content.json
@@ -1,0 +1,19 @@
+{
+  "doors": [
+    {
+      "day": 1,
+      "text": "Quelqu'un a un message pour vous",
+      "type": "video",
+      "url": "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4",
+      "poster": "media/cadre.jpg",
+      "caption": "Touchez play pour découvrir la surprise du jour."
+    },
+    {
+      "day": 2,
+      "text": "Un souvenir à partager",
+      "type": "photo",
+      "url": "media/cadre.jpg",
+      "caption": "Remplacez cette image par votre photo du jour."
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1035,6 +1035,18 @@
 
 
     </div>
+    <div class="door-modal" id="door-surprise-modal" data-door-modal aria-hidden="true">
+        <div class="door-modal__overlay" data-modal-close></div>
+        <div class="door-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="door-modal-title"
+            tabindex="-1">
+            <button type="button" class="door-modal__close" data-modal-close data-modal-initial-focus
+                aria-label="Fermer le message">
+                <span aria-hidden="true">&times;</span>
+            </button>
+            <h2 id="door-modal-title" class="door-modal__title" data-modal-title></h2>
+            <div class="door-modal__body" data-modal-body></div>
+        </div>
+    </div>
     <div class="message"></div>
 </body>
 

--- a/media/gift.svg
+++ b/media/gift.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+  <defs>
+    <linearGradient id="giftBody" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#ff6f61" />
+      <stop offset="1" stop-color="#e53935" />
+    </linearGradient>
+    <linearGradient id="giftLid" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#ff8a80" />
+      <stop offset="1" stop-color="#ef5350" />
+    </linearGradient>
+    <linearGradient id="giftRibbon" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#fff59d" />
+      <stop offset="1" stop-color="#f9a825" />
+    </linearGradient>
+  </defs>
+  <rect x="34" y="88" width="172" height="124" rx="20" fill="url(#giftBody)" />
+  <rect x="34" y="88" width="172" height="72" rx="20" fill="url(#giftLid)" />
+  <rect x="34" y="140" width="172" height="22" fill="url(#giftRibbon)" />
+  <rect x="108" y="88" width="24" height="124" fill="url(#giftRibbon)" />
+  <path d="M120 70C108 22 56 28 46 60C36 94 70 110 104 100C94 92 94 74 120 70Z" fill="#ffcc80" />
+  <path d="M120 70C132 22 184 28 194 60C204 94 170 110 136 100C146 92 146 74 120 70Z" fill="#ffcc80" />
+  <path d="M104 60C90 44 62 44 54 66C48 82 58 96 82 100C78 82 88 68 104 60Z" fill="#f48fb1" />
+  <path d="M136 60C150 44 178 44 186 66C192 82 182 96 158 100C162 82 152 68 136 60Z" fill="#f48fb1" />
+  <rect x="106" y="62" width="28" height="44" rx="10" fill="url(#giftRibbon)" />
+</svg>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 const storageKey = 'advent-calendar-opened-doors';
 const startDate = new Date(2025, 8, 16);
 startDate.setHours(0, 0, 0, 0);
+const doorContentConfigUrl = 'door-content.json';
 
 function getReleaseDate(index) {
   const date = new Date(startDate);
@@ -60,110 +61,617 @@ function formatDuration(ms) {
   return parts.join(' ');
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  const panes = Array.from(document.querySelectorAll('.door__hinge__pane'));
-  if (!panes.length) {
+function normalizeDoorContentEntry(day, entry) {
+  const normalizedDay = Number(day);
+  if (!Number.isInteger(normalizedDay) || normalizedDay < 1) {
+    return null;
+  }
+
+  const fallbackMessage = "Le cadeau de ce jour n'est pas encore prêt.";
+  const normalized = {
+    day: normalizedDay,
+    title: `Cadeau du jour ${normalizedDay}`,
+    type: 'none',
+    url: '',
+    poster: '',
+    alt: '',
+    caption: '',
+    fallbackMessage,
+  };
+
+  if (typeof entry === 'string') {
+    const text = entry.trim();
+    if (text) {
+      normalized.title = text;
+    }
+    return normalized;
+  }
+
+  const source = entry && typeof entry === 'object' ? entry : {};
+
+  if (typeof source.text === 'string' && source.text.trim()) {
+    normalized.title = source.text.trim();
+  }
+
+  if (typeof source.caption === 'string' && source.caption.trim()) {
+    normalized.caption = source.caption.trim();
+  }
+
+  if (typeof source.fallback === 'string' && source.fallback.trim()) {
+    normalized.fallbackMessage = source.fallback.trim();
+  }
+
+  if (typeof source.type === 'string') {
+    const type = source.type.trim().toLowerCase();
+    if (type === 'video') {
+      normalized.type = 'video';
+    } else if (type === 'photo' || type === 'image' || type === 'picture') {
+      normalized.type = 'photo';
+    }
+  }
+
+  if (typeof source.url === 'string' && source.url.trim()) {
+    normalized.url = source.url.trim();
+  }
+
+  if (typeof source.poster === 'string' && source.poster.trim()) {
+    normalized.poster = source.poster.trim();
+  }
+
+  if (typeof source.alt === 'string' && source.alt.trim()) {
+    normalized.alt = source.alt.trim();
+  }
+
+  if (normalized.type === 'photo' && !normalized.alt) {
+    normalized.alt = normalized.title;
+  }
+
+  if ((normalized.type === 'video' || normalized.type === 'photo') && !normalized.url) {
+    normalized.type = 'none';
+  }
+
+  return normalized;
+}
+
+function normalizeDoorContentCollection(raw) {
+  const map = new Map();
+
+  const processEntry = (dayValue, value, index) => {
+    let day = Number(dayValue);
+    if (value && typeof value === 'object' && 'day' in value) {
+      const entryDay = Number(value.day);
+      if (Number.isInteger(entryDay) && entryDay >= 1) {
+        day = entryDay;
+      }
+    }
+    if (!Number.isInteger(day) || day < 1) {
+      day = index + 1;
+    }
+    const normalized = normalizeDoorContentEntry(day, value);
+    if (normalized) {
+      map.set(day, normalized);
+    }
+  };
+
+  if (Array.isArray(raw)) {
+    raw.forEach((item, index) => {
+      const dayValue =
+        item && typeof item === 'object' && 'day' in item ? item.day : index + 1;
+      processEntry(dayValue, item, index);
+    });
+  } else if (raw && typeof raw === 'object') {
+    if (Array.isArray(raw.doors)) {
+      raw.doors.forEach((item, index) => {
+        const dayValue =
+          item && typeof item === 'object' && 'day' in item ? item.day : index + 1;
+        processEntry(dayValue, item, index);
+      });
+    } else if (raw.doors && typeof raw.doors === 'object') {
+      Object.entries(raw.doors).forEach(([key, value], index) => {
+        processEntry(key, value, index);
+      });
+    } else {
+      Object.entries(raw).forEach(([key, value], index) => {
+        processEntry(key, value, index);
+      });
+    }
+  }
+
+  return map;
+}
+
+async function fetchDoorContentConfig(url) {
+  if (!window.fetch) {
+    return new Map();
+  }
+
+  try {
+    const response = await fetch(url, { cache: 'no-cache' });
+    if (!response.ok) {
+      throw new Error(`Statut ${response.status}`);
+    }
+    const data = await response.json();
+    return normalizeDoorContentCollection(data);
+  } catch (error) {
+    console.warn('Impossible de charger le contenu des cadeaux :', error);
+    return new Map();
+  }
+}
+
+function createModalManager(modalElement) {
+  if (!(modalElement instanceof HTMLElement)) {
+    return {
+      open: () => {},
+      close: () => {},
+      isOpen: () => false,
+      isForDay: () => false,
+    };
+  }
+
+  const closeElements = Array.from(modalElement.querySelectorAll('[data-modal-close]'));
+  const titleElement = modalElement.querySelector('[data-modal-title]');
+  const bodyElement = modalElement.querySelector('[data-modal-body]');
+
+  let lastFocusedElement = null;
+  let activeVideo = null;
+  let activeDay = null;
+
+  const focusableSelectors = [
+    'button',
+    '[href]',
+    'input',
+    'select',
+    'textarea',
+    '[tabindex]:not([tabindex="-1"])',
+    'video',
+  ];
+
+  function setBodyModalState(isOpen) {
+    document.body.classList.toggle('body--modal-open', isOpen);
+  }
+
+  function clearActiveMedia() {
+    if (activeVideo instanceof HTMLVideoElement) {
+      activeVideo.pause();
+      activeVideo.currentTime = 0;
+    }
+    activeVideo = null;
+  }
+
+  function updateModalBody(nodes) {
+    if (!bodyElement) {
+      return;
+    }
+
+    if (typeof bodyElement.replaceChildren === 'function') {
+      bodyElement.replaceChildren(...nodes);
+    } else {
+      bodyElement.innerHTML = '';
+      nodes.forEach((node) => {
+        bodyElement.appendChild(node);
+      });
+    }
+  }
+
+  function renderContent(day, entry) {
+    const normalized = entry || normalizeDoorContentEntry(day, null);
+
+    if (titleElement) {
+      titleElement.textContent = normalized ? normalized.title : '';
+    }
+
+    clearActiveMedia();
+    const nodes = [];
+
+    if (!normalized) {
+      const fallback = document.createElement('p');
+      fallback.className = 'door-modal__fallback';
+      fallback.textContent = "Le cadeau de ce jour n'est pas encore prêt.";
+      nodes.push(fallback);
+      updateModalBody(nodes);
+      return;
+    }
+
+    if (normalized.type === 'video') {
+      const video = document.createElement('video');
+      video.className = 'door-modal__video';
+      video.controls = true;
+      video.preload = 'metadata';
+      video.playsInline = true;
+      video.setAttribute('playsinline', '');
+      video.setAttribute('webkit-playsinline', '');
+      video.src = normalized.url;
+      if (normalized.poster) {
+        video.poster = normalized.poster;
+      }
+      video.innerHTML = 'Votre navigateur ne supporte pas la lecture vidéo.';
+      nodes.push(video);
+
+      if (normalized.caption) {
+        const caption = document.createElement('p');
+        caption.className = 'door-modal__caption';
+        caption.textContent = normalized.caption;
+        nodes.push(caption);
+      }
+
+      activeVideo = video;
+    } else if (normalized.type === 'photo') {
+      const figure = document.createElement('figure');
+      figure.className = 'door-modal__figure';
+
+      const image = document.createElement('img');
+      image.className = 'door-modal__image';
+      image.src = normalized.url;
+      image.alt = normalized.alt || normalized.title;
+      figure.appendChild(image);
+
+      if (normalized.caption) {
+        const caption = document.createElement('figcaption');
+        caption.className = 'door-modal__caption';
+        caption.textContent = normalized.caption;
+        figure.appendChild(caption);
+      }
+
+      nodes.push(figure);
+    } else {
+      const fallback = document.createElement('p');
+      fallback.className = 'door-modal__fallback';
+      fallback.textContent = normalized.fallbackMessage;
+      nodes.push(fallback);
+    }
+
+    updateModalBody(nodes);
+  }
+
+  function open(day, entry) {
+    renderContent(day, entry);
+
+    lastFocusedElement =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    modalElement.classList.add('door-modal--visible');
+    modalElement.setAttribute('aria-hidden', 'false');
+    setBodyModalState(true);
+
+    const initialFocus = modalElement.querySelector('[data-modal-initial-focus]');
+    if (initialFocus instanceof HTMLElement) {
+      initialFocus.focus({ preventScroll: true });
+    } else {
+      const dialog = modalElement.querySelector('.door-modal__dialog');
+      if (dialog instanceof HTMLElement) {
+        dialog.focus({ preventScroll: true });
+      }
+    }
+
+    if (activeVideo instanceof HTMLVideoElement) {
+      const playPromise = activeVideo.play();
+      if (playPromise && typeof playPromise.then === 'function') {
+        playPromise.catch(() => {});
+      }
+    }
+
+    activeDay = day;
+  }
+
+  function close() {
+    if (!isOpen()) {
+      return;
+    }
+
+    clearActiveMedia();
+
+    updateModalBody([]);
+
+    modalElement.classList.remove('door-modal--visible');
+    modalElement.setAttribute('aria-hidden', 'true');
+    setBodyModalState(false);
+
+    if (lastFocusedElement && document.contains(lastFocusedElement)) {
+      lastFocusedElement.focus({ preventScroll: true });
+    }
+
+    lastFocusedElement = null;
+    activeDay = null;
+  }
+
+  function isOpen() {
+    return modalElement.classList.contains('door-modal--visible');
+  }
+
+  function isForDay(day) {
+    return activeDay === day;
+  }
+
+  function trapFocus(event) {
+    const focusableElements = Array.from(
+      modalElement.querySelectorAll(focusableSelectors.join(', '))
+    ).filter(
+      (element) =>
+        element instanceof HTMLElement &&
+        !element.hasAttribute('disabled') &&
+        element.tabIndex !== -1 &&
+        element.offsetParent !== null
+    );
+
+    if (!focusableElements.length) {
+      return;
+    }
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (event.shiftKey) {
+      if (document.activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus({ preventScroll: true });
+      }
+    } else if (document.activeElement === lastElement) {
+      event.preventDefault();
+      firstElement.focus({ preventScroll: true });
+    }
+  }
+
+  closeElements.forEach((element) => {
+    element.addEventListener('click', (event) => {
+      event.preventDefault();
+      close();
+    });
+  });
+
+  modalElement.addEventListener('click', (event) => {
+    if (event.target === modalElement) {
+      close();
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (!isOpen()) {
+      return;
+    }
+
+    if (event.key === 'Escape' || event.key === 'Esc') {
+      event.preventDefault();
+      close();
+    } else if (event.key === 'Tab') {
+      trapFocus(event);
+    }
+  });
+
+  return {
+    open,
+    close,
+    isOpen,
+    isForDay,
+  };
+}
+
+function ensureDoorGiftSetup(doorElement, dayNumber, modalManager, doorContentMap) {
+  if (!(doorElement instanceof HTMLElement)) {
     return;
   }
 
-  const unlockedSet = loadUnlockedSet();
+  doorElement.classList.add('door--has-gift');
 
-  const doors = panes.map((pane, index) => {
-    const doorElement = pane.closest('.door');
-    let countdown = doorElement.querySelector('.message');
-    if (!countdown) {
-      countdown = document.createElement('div');
-      countdown.className = 'message';
-      doorElement.appendChild(countdown);
-    }
-
-    const label = pane.querySelector('.number');
-    if (label) {
-      label.textContent = String(index + 1);
-    }
-
-    const releaseDate = getReleaseDate(index);
-    pane.dataset.releaseDate = releaseDate.toISOString();
-
-    if (unlockedSet.has(index)) {
-      pane.classList.add('door__hinge__pane--open');
-      doorElement.classList.add('door--opened', 'door--unlocked');
-    }
-
-    return {
-      index,
-      pane,
-      doorElement,
-      countdown,
-      releaseDate,
-    };
-  });
-
-  function arePreviousUnlocked(index) {
-    for (let i = 0; i < index; i += 1) {
-      if (!unlockedSet.has(i)) {
-        return false;
-      }
-    }
-    return true;
+  let content = doorElement.querySelector('.door__content');
+  if (!(content instanceof HTMLElement)) {
+    content = document.createElement('div');
+    content.className = 'door__content door__content--gift';
+    doorElement.appendChild(content);
+  } else {
+    content.classList.add('door__content--gift');
   }
 
-  function updateDoorStates() {
-    const now = new Date();
-    let nextLockedDoor = null;
+  content.setAttribute('aria-hidden', 'true');
+
+  let button = content.querySelector('[data-door-gift-button]');
+  if (!(button instanceof HTMLButtonElement)) {
+    button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'door__gift-button';
+    content.appendChild(button);
+  }
+
+  button.setAttribute('data-door-gift-button', '');
+  button.dataset.day = String(dayNumber);
+  button.setAttribute('aria-haspopup', 'dialog');
+  button.setAttribute('aria-controls', 'door-surprise-modal');
+  button.setAttribute('aria-label', 'Ouvrir le cadeau');
+
+  let image = button.querySelector('.door__gift-image');
+  if (!(image instanceof HTMLImageElement)) {
+    image = document.createElement('img');
+    image.className = 'door__gift-image';
+    image.setAttribute('aria-hidden', 'true');
+    button.appendChild(image);
+  }
+
+  image.src = 'media/gift.svg';
+  image.alt = '';
+
+  if (!button.dataset.giftListenerAttached) {
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (!modalManager || typeof modalManager.open !== 'function') {
+        return;
+      }
+
+      if (!doorElement.classList.contains('door--opened')) {
+        return;
+      }
+
+      const day = Number(button.dataset.day);
+      const entry = doorContentMap.get(day) || null;
+      modalManager.open(day, entry);
+    });
+
+    button.dataset.giftListenerAttached = 'true';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  try {
+    const modalElement = document.querySelector('[data-door-modal]');
+    const modalManager = createModalManager(modalElement);
+    const doorContentMap = await fetchDoorContentConfig(doorContentConfigUrl);
+
+    const panes = Array.from(document.querySelectorAll('.door__hinge__pane'));
+    if (!panes.length) {
+      return;
+    }
+
+    const unlockedSet = loadUnlockedSet();
+
+    function updateDoorContentVisibility(doorElement, dayNumber, isOpen) {
+      const content = doorElement.querySelector('.door__content');
+      if (content) {
+        content.setAttribute('aria-hidden', String(!isOpen));
+        const button = content.querySelector('[data-door-gift-button]');
+        if (button instanceof HTMLElement) {
+          if (isOpen) {
+            button.removeAttribute('tabindex');
+          } else {
+            button.setAttribute('tabindex', '-1');
+          }
+        }
+      }
+
+      if (!isOpen && modalManager && typeof modalManager.isForDay === 'function') {
+        if (modalManager.isForDay(dayNumber)) {
+          modalManager.close();
+        }
+      }
+    }
+
+    const doors = panes
+      .map((pane, index) => {
+        const doorElement = pane.closest('.door');
+        if (!doorElement) {
+          return null;
+        }
+
+        const dayNumber = index + 1;
+
+        ensureDoorGiftSetup(doorElement, dayNumber, modalManager, doorContentMap);
+
+        let countdown = doorElement.querySelector('.message');
+        if (!(countdown instanceof HTMLElement)) {
+          countdown = document.createElement('div');
+          countdown.className = 'message';
+          doorElement.appendChild(countdown);
+        }
+
+        const label = pane.querySelector('.number');
+        if (label) {
+          label.textContent = String(dayNumber);
+        }
+
+        const releaseDate = getReleaseDate(index);
+        pane.dataset.releaseDate = releaseDate.toISOString();
+
+        if (unlockedSet.has(index)) {
+          pane.classList.add('door__hinge__pane--open');
+          doorElement.classList.add('door--opened', 'door--unlocked');
+        }
+
+        const doorData = {
+          index,
+          dayNumber,
+          pane,
+          doorElement,
+          countdown,
+          releaseDate,
+        };
+
+        const isOpen = pane.classList.contains('door__hinge__pane--open');
+        updateDoorContentVisibility(doorElement, dayNumber, isOpen);
+
+        return doorData;
+      })
+      .filter((doorData) => doorData !== null);
+
+    function arePreviousUnlocked(index) {
+      for (let i = 0; i < index; i += 1) {
+        if (!unlockedSet.has(i)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    function updateDoorStates() {
+      const now = new Date();
+      let nextLockedDoor = null;
+
+      doors.forEach((door) => {
+        const unlocked = unlockedSet.has(door.index);
+        const isOpen = door.pane.classList.contains('door__hinge__pane--open');
+        const previousUnlocked = arePreviousUnlocked(door.index);
+        const availableByDate = now >= door.releaseDate;
+        const canOpen = previousUnlocked && availableByDate;
+
+        door.doorElement.classList.toggle('door--available', !unlocked && canOpen);
+        door.doorElement.classList.toggle('door--locked', !unlocked && !canOpen);
+        door.doorElement.classList.toggle('door--unlocked', unlocked);
+        door.doorElement.classList.toggle('door--opened', isOpen);
+
+        door.countdown.textContent = '';
+        door.countdown.classList.remove('door__countdown--visible');
+        door.doorElement.classList.remove('door--show-countdown');
+
+        updateDoorContentVisibility(door.doorElement, door.dayNumber, isOpen);
+
+        if (!unlocked && !nextLockedDoor && previousUnlocked) {
+          nextLockedDoor = door;
+        }
+      });
+
+      if (nextLockedDoor) {
+        const diff = nextLockedDoor.releaseDate.getTime() - now.getTime();
+        if (diff > 0) {
+          nextLockedDoor.countdown.textContent = `Prochain cadeau dans ${formatDuration(diff)}`;
+          nextLockedDoor.countdown.classList.add('door__countdown--visible');
+          nextLockedDoor.doorElement.classList.add('door--show-countdown');
+        }
+      }
+    }
 
     doors.forEach((door) => {
-      const unlocked = unlockedSet.has(door.index);
-      const isOpen = door.pane.classList.contains('door__hinge__pane--open');
-      const previousUnlocked = arePreviousUnlocked(door.index);
-      const availableByDate = now >= door.releaseDate;
-      const canOpen = previousUnlocked && availableByDate;
-
-      door.doorElement.classList.toggle('door--available', !unlocked && canOpen);
-      door.doorElement.classList.toggle('door--locked', !unlocked && !canOpen);
-      door.doorElement.classList.toggle('door--unlocked', unlocked);
-      door.doorElement.classList.toggle('door--opened', isOpen);
-
-      door.countdown.textContent = '';
-      door.countdown.classList.remove('door__countdown--visible');
-      door.doorElement.classList.remove('door--show-countdown');
-
-      if (!unlocked && !nextLockedDoor && previousUnlocked) {
-        nextLockedDoor = door;
-      }
-    });
-
-    if (nextLockedDoor) {
-      const diff = nextLockedDoor.releaseDate.getTime() - now.getTime();
-      if (diff > 0) {
-        nextLockedDoor.countdown.textContent = `Prochain cadeau dans ${formatDuration(diff)}`;
-        nextLockedDoor.countdown.classList.add('door__countdown--visible');
-        nextLockedDoor.doorElement.classList.add('door--show-countdown');
-      }
-    }
-  }
-
-  doors.forEach((door) => {
-    door.pane.addEventListener('click', () => {
-      const unlocked = unlockedSet.has(door.index);
-      const now = new Date();
-
-      if (!unlocked) {
-        if (!arePreviousUnlocked(door.index) || now < door.releaseDate) {
+      door.pane.addEventListener('click', (event) => {
+        const content = door.doorElement.querySelector('.door__content');
+        if (
+          content &&
+          event.target instanceof Node &&
+          content.contains(event.target)
+        ) {
           return;
         }
-        unlockedSet.add(door.index);
-        persistUnlockedSet(unlockedSet);
-      }
 
-      const isOpen = door.pane.classList.toggle('door__hinge__pane--open');
-      door.doorElement.classList.toggle('door--opened', isOpen);
-      door.doorElement.classList.add('door--unlocked');
+        const unlocked = unlockedSet.has(door.index);
+        const now = new Date();
 
-      updateDoorStates();
+        if (!unlocked) {
+          if (!arePreviousUnlocked(door.index) || now < door.releaseDate) {
+            return;
+          }
+          unlockedSet.add(door.index);
+          persistUnlockedSet(unlockedSet);
+        }
+
+        const isOpen = door.pane.classList.toggle('door__hinge__pane--open');
+        door.doorElement.classList.toggle('door--opened', isOpen);
+        door.doorElement.classList.add('door--unlocked');
+
+        updateDoorContentVisibility(door.doorElement, door.dayNumber, isOpen);
+
+        updateDoorStates();
+      });
     });
-  });
 
-  updateDoorStates();
-  setInterval(updateDoorStates, 1000);
+    updateDoorStates();
+    setInterval(updateDoorStates, 1000);
+  } catch (error) {
+    console.error("Erreur lors de l'initialisation du calendrier :", error);
+  }
 });

--- a/styles.css
+++ b/styles.css
@@ -169,10 +169,224 @@ font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-seri
   .door__hinge__pane--thirty-nine { --col: 3; --row: 7; }
   .door__hinge__pane--fourty { --col: 4; --row: 7; }
 
-  .cube {
+.cube {
   position: absolute;
   top: var(--cell-padding);
   left: var(--cell-padding); }
+
+.door__content {
+  position: absolute;
+  top: var(--cell-padding);
+  left: var(--cell-padding);
+  width: calc(0.8 * var(--door-size));
+  height: calc(0.8 * var(--door-size));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px;
+  box-sizing: border-box;
+  border-radius: 16px;
+  background-image: url('media/cadre.jpg');
+  background-size: cover;
+  background-position: center;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+  z-index: 2;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+}
+
+.door--opened .door__content {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  z-index: 4;
+}
+
+.door__content--gift {
+  padding: 8px;
+  background-image: none;
+  background-color: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3);
+  -webkit-backdrop-filter: blur(3px);
+  backdrop-filter: blur(3px);
+}
+
+.door__gift-button {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.door__gift-button:focus-visible {
+  outline: 2px solid #f9a825;
+  outline-offset: 4px;
+}
+
+.door__gift-image {
+  width: 100%;
+  height: auto;
+  max-width: 140px;
+  transform-origin: 50% 100%;
+  animation: gift-bounce 2.4s ease-in-out infinite;
+  filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.35));
+}
+
+@keyframes gift-bounce {
+  0%,
+  100% {
+    transform: translateY(0) scale(1);
+  }
+
+  50% {
+    transform: translateY(-8px) scale(1.03);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .door__gift-image {
+    animation: none;
+  }
+}
+
+.door-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background-color: rgba(0, 0, 0, 0.65);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 20;
+}
+
+.door-modal--visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.door-modal__overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  cursor: pointer;
+}
+
+.door-modal__dialog {
+  position: relative;
+  z-index: 1;
+  width: min(90vw, 520px);
+  border-radius: 24px;
+  background: linear-gradient(145deg, #fffdf5, #ffe7d1);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+  padding: clamp(20px, 5vw, 32px);
+  text-align: center;
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+}
+
+.door-modal__close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.65);
+  color: #fff;
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.door-modal__close:hover,
+.door-modal__close:focus-visible {
+  background: rgba(0, 0, 0, 0.8);
+  transform: scale(1.05);
+  outline: none;
+}
+
+.door-modal__close span {
+  transform: translateY(-1px);
+}
+
+.door-modal__body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.door-modal__title {
+  margin: 0 0 20px;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  color: #b23a48;
+  font-weight: 700;
+}
+
+.door-modal__video {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: none;
+  border-radius: 18px;
+  background-color: #000;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.4);
+  max-height: min(60vh, 400px);
+  object-fit: cover;
+}
+
+.door-modal__figure {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+}
+
+.door-modal__image {
+  width: 100%;
+  height: auto;
+  border-radius: 18px;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.4);
+  object-fit: cover;
+}
+
+.door-modal__caption {
+  margin: 0;
+  font-size: 1rem;
+  color: #5a3d2b;
+  text-align: center;
+}
+
+.door-modal__fallback {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #5a3d2b;
+  text-align: center;
+}
+
+.body--modal-open {
+  overflow: hidden;
+}
 
 .cube__container {
   width: calc(0.8 * var(--door-size));


### PR DESCRIPTION
## Summary
- lower the z-index of revealed door content so an opened panel now covers the neighbouring gift instead of slipping behind it
- refactor the modal renderer to replace its body nodes, guaranteeing that each day's media fully replaces the previous content when a gift opens or closes

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8a2b9b91c832590053bbc11414336